### PR TITLE
[dsp] remove /dsp symlink. JB#42774

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -98,8 +98,6 @@ TARGET_NO_RECOVERY := true
 BOARD_USES_RECOVERY_AS_BOOT := true
 BOARD_BUILD_SYSTEM_ROOT_IMAGE := true
 
-BOARD_ROOT_EXTRA_SYMLINKS := /vendor/lib/dsp:/dsp
-
 BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 
 include device/sony/common/CommonConfig.mk


### PR DESCRIPTION
we mount the dsp partition on the /dsp folder and we should create a symlink
to /vendor/lib/dsp

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>